### PR TITLE
Use JSON as intermediate config representation and add a switch -DdumpParentConfig

### DIFF
--- a/How_To_Fuzz.md
+++ b/How_To_Fuzz.md
@@ -38,3 +38,4 @@ Optional:
 - -Dannotation.instrument (Automatically add @RunWith, @Fuzz annotation)
 - -Dgenerator.nostring
 - -DnotPrintConfig (Do not print the changed configuration information)
+- -DdumpParentConfig (dump parent configuration JSONs into fuzz-result/)

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ZestGuidance.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ZestGuidance.java
@@ -68,6 +68,9 @@ import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
 import static java.lang.Math.ceil;
 import static java.lang.Math.log;
 
+import com.google.gson.GsonBuilder;
+import com.google.gson.Gson;
+
 /**
  * A guidance that performs coverage-guided fuzzing using two coverage maps,
  * one for all inputs and one for valid inputs only.
@@ -819,7 +822,7 @@ public class ZestGuidance implements Guidance {
                         File parentFile = new File(savedFailuresDirectory, parentFileName);
                         GuidanceException.wrap(() -> writeParentInputToFile(parentFile));
 
-                        String configFileName = String.format("config_%06d", crashIdx);
+                        String configFileName = String.format("config_%06d.json", crashIdx);
                         File configFile = new File(savedFailuresDirectory, configFileName);
                         GuidanceException.wrap(() -> writeCurrentConfigToFile(configFile));
                     }
@@ -857,7 +860,7 @@ public class ZestGuidance implements Guidance {
                     File parentFile = new File(savedFailuresDirectory, parentFileName);
                     GuidanceException.wrap(() -> writeParentInputToFile(parentFile));
 
-                    String configFileName = String.format("config_%06d", numTrials);
+                    String configFileName = String.format("config_%06d.json", numTrials);
                     File configFile = new File(savedFailuresDirectory, configFileName);
                     GuidanceException.wrap(() -> writeCurrentConfigToFile(configFile));
                 }
@@ -994,12 +997,10 @@ public class ZestGuidance implements Guidance {
         // No need to write configuration file if it is not configuration fuzzing
         if (!Boolean.getBoolean("configFuzz"))
             return;
-        try (PrintWriter out = new PrintWriter(new FileWriter(configFile, false))) {
-            for (Map.Entry<String, String> entry : ConfigTracker.getConfigMap().entrySet()) {
-                String paramName = entry.getKey();
-                String paramValue = entry.getValue();
-                out.write(paramName + configSeparator + paramValue + "\n");
-            }
+        Gson gson = new GsonBuilder().serializeNulls().create();
+        String jsonStr = gson.toJson(ConfigTracker.getConfigMap());
+        try (PrintWriter out = new PrintWriter(configFile)) {
+            out.println(jsonStr);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,13 @@
         <module>maven-plugin</module>
     </modules>
 
+    <dependencies>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10</version>
+        </dependency>
+    </dependencies>
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
Use JSON to save failed config
Add a switch -DdumpParentConfig for dumpting configs in JSON format.
Update the How_to_Fuzz accordingly